### PR TITLE
Fix small typo

### DIFF
--- a/public_html/index.html
+++ b/public_html/index.html
@@ -68,7 +68,7 @@
     <div class="span6">
       <div class="well">
         <h3>About</h3>
-        <p>Twitch sometimes has "twitches" in its infrastructue, and their response time to outages can be lacking. This page serves as a tool to unofficially check on service problems at Twitch.<br /><br />
+        <p>Twitch sometimes has "twitches" in its infrastructure, and their response time to outages can be lacking. This page serves as a tool to unofficially check on service problems at Twitch.<br /><br />
         </p>
       </div>
     </div>


### PR DESCRIPTION
Replaces "infrastructue" with "infrastructure" on the main page.

Thanks,
Elliott